### PR TITLE
fix: import auth plugins

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"github.com/jasonrichardsmith/rbac-view/client"
 	"github.com/jasonrichardsmith/rbac-view/matrix"
 	"github.com/jasonrichardsmith/rbac-view/render"


### PR DESCRIPTION
Awesome project! I required this fix to use GKE, although the same import allows auth with GKE/Azure/OIDC/openstack.